### PR TITLE
Make SwiftHTTPStatusCodes Carthage compatible

### DIFF
--- a/HTTPStatusCodes/HTTPStatusCodes.xcodeproj/project.pbxproj
+++ b/HTTPStatusCodes/HTTPStatusCodes.xcodeproj/project.pbxproj
@@ -1,0 +1,420 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		908CDFB01B5966CB0009CA5D /* HTTPStatusCodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 908CDFAF1B5966CB0009CA5D /* HTTPStatusCodes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		908CDFB61B5966CB0009CA5D /* HTTPStatusCodes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 908CDFAA1B5966CB0009CA5D /* HTTPStatusCodes.framework */; };
+		908CDFBD1B5966CB0009CA5D /* HTTPStatusCodesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908CDFBC1B5966CB0009CA5D /* HTTPStatusCodesTests.swift */; };
+		908CDFC71B596D280009CA5D /* HTTPStatusCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908CDFC61B596D280009CA5D /* HTTPStatusCodes.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		908CDFB71B5966CB0009CA5D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 908CDFA11B5966CB0009CA5D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 908CDFA91B5966CB0009CA5D;
+			remoteInfo = HTTPStatusCodes;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		908CDFAA1B5966CB0009CA5D /* HTTPStatusCodes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HTTPStatusCodes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		908CDFAE1B5966CB0009CA5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		908CDFAF1B5966CB0009CA5D /* HTTPStatusCodes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HTTPStatusCodes.h; sourceTree = "<group>"; };
+		908CDFB51B5966CB0009CA5D /* HTTPStatusCodesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HTTPStatusCodesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		908CDFBB1B5966CB0009CA5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		908CDFBC1B5966CB0009CA5D /* HTTPStatusCodesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCodesTests.swift; sourceTree = "<group>"; };
+		908CDFC61B596D280009CA5D /* HTTPStatusCodes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HTTPStatusCodes.swift; path = ../../HTTPStatusCodes.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		908CDFA61B5966CB0009CA5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		908CDFB21B5966CB0009CA5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				908CDFB61B5966CB0009CA5D /* HTTPStatusCodes.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		908CDFA01B5966CB0009CA5D = {
+			isa = PBXGroup;
+			children = (
+				908CDFAC1B5966CB0009CA5D /* HTTPStatusCodes */,
+				908CDFB91B5966CB0009CA5D /* HTTPStatusCodesTests */,
+				908CDFAB1B5966CB0009CA5D /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		908CDFAB1B5966CB0009CA5D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				908CDFAA1B5966CB0009CA5D /* HTTPStatusCodes.framework */,
+				908CDFB51B5966CB0009CA5D /* HTTPStatusCodesTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		908CDFAC1B5966CB0009CA5D /* HTTPStatusCodes */ = {
+			isa = PBXGroup;
+			children = (
+				908CDFC61B596D280009CA5D /* HTTPStatusCodes.swift */,
+				908CDFAF1B5966CB0009CA5D /* HTTPStatusCodes.h */,
+				908CDFAD1B5966CB0009CA5D /* Supporting Files */,
+			);
+			path = HTTPStatusCodes;
+			sourceTree = "<group>";
+		};
+		908CDFAD1B5966CB0009CA5D /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				908CDFAE1B5966CB0009CA5D /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		908CDFB91B5966CB0009CA5D /* HTTPStatusCodesTests */ = {
+			isa = PBXGroup;
+			children = (
+				908CDFBC1B5966CB0009CA5D /* HTTPStatusCodesTests.swift */,
+				908CDFBA1B5966CB0009CA5D /* Supporting Files */,
+			);
+			path = HTTPStatusCodesTests;
+			sourceTree = "<group>";
+		};
+		908CDFBA1B5966CB0009CA5D /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				908CDFBB1B5966CB0009CA5D /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		908CDFA71B5966CB0009CA5D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				908CDFB01B5966CB0009CA5D /* HTTPStatusCodes.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		908CDFA91B5966CB0009CA5D /* HTTPStatusCodes */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 908CDFC01B5966CB0009CA5D /* Build configuration list for PBXNativeTarget "HTTPStatusCodes" */;
+			buildPhases = (
+				908CDFA51B5966CB0009CA5D /* Sources */,
+				908CDFA61B5966CB0009CA5D /* Frameworks */,
+				908CDFA71B5966CB0009CA5D /* Headers */,
+				908CDFA81B5966CB0009CA5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HTTPStatusCodes;
+			productName = HTTPStatusCodes;
+			productReference = 908CDFAA1B5966CB0009CA5D /* HTTPStatusCodes.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		908CDFB41B5966CB0009CA5D /* HTTPStatusCodesTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 908CDFC31B5966CB0009CA5D /* Build configuration list for PBXNativeTarget "HTTPStatusCodesTests" */;
+			buildPhases = (
+				908CDFB11B5966CB0009CA5D /* Sources */,
+				908CDFB21B5966CB0009CA5D /* Frameworks */,
+				908CDFB31B5966CB0009CA5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				908CDFB81B5966CB0009CA5D /* PBXTargetDependency */,
+			);
+			name = HTTPStatusCodesTests;
+			productName = HTTPStatusCodesTests;
+			productReference = 908CDFB51B5966CB0009CA5D /* HTTPStatusCodesTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		908CDFA11B5966CB0009CA5D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0640;
+				ORGANIZATIONNAME = HTTPStatusCodes;
+				TargetAttributes = {
+					908CDFA91B5966CB0009CA5D = {
+						CreatedOnToolsVersion = 6.4;
+					};
+					908CDFB41B5966CB0009CA5D = {
+						CreatedOnToolsVersion = 6.4;
+					};
+				};
+			};
+			buildConfigurationList = 908CDFA41B5966CB0009CA5D /* Build configuration list for PBXProject "HTTPStatusCodes" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 908CDFA01B5966CB0009CA5D;
+			productRefGroup = 908CDFAB1B5966CB0009CA5D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				908CDFA91B5966CB0009CA5D /* HTTPStatusCodes */,
+				908CDFB41B5966CB0009CA5D /* HTTPStatusCodesTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		908CDFA81B5966CB0009CA5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		908CDFB31B5966CB0009CA5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		908CDFA51B5966CB0009CA5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				908CDFC71B596D280009CA5D /* HTTPStatusCodes.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		908CDFB11B5966CB0009CA5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				908CDFBD1B5966CB0009CA5D /* HTTPStatusCodesTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		908CDFB81B5966CB0009CA5D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 908CDFA91B5966CB0009CA5D /* HTTPStatusCodes */;
+			targetProxy = 908CDFB71B5966CB0009CA5D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		908CDFBE1B5966CB0009CA5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		908CDFBF1B5966CB0009CA5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		908CDFC11B5966CB0009CA5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = HTTPStatusCodes/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		908CDFC21B5966CB0009CA5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = HTTPStatusCodes/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		908CDFC41B5966CB0009CA5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = HTTPStatusCodesTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		908CDFC51B5966CB0009CA5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = HTTPStatusCodesTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		908CDFA41B5966CB0009CA5D /* Build configuration list for PBXProject "HTTPStatusCodes" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				908CDFBE1B5966CB0009CA5D /* Debug */,
+				908CDFBF1B5966CB0009CA5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		908CDFC01B5966CB0009CA5D /* Build configuration list for PBXNativeTarget "HTTPStatusCodes" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				908CDFC11B5966CB0009CA5D /* Debug */,
+				908CDFC21B5966CB0009CA5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		908CDFC31B5966CB0009CA5D /* Build configuration list for PBXNativeTarget "HTTPStatusCodesTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				908CDFC41B5966CB0009CA5D /* Debug */,
+				908CDFC51B5966CB0009CA5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 908CDFA11B5966CB0009CA5D /* Project object */;
+}

--- a/HTTPStatusCodes/HTTPStatusCodes.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/HTTPStatusCodes/HTTPStatusCodes.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:HTTPStatusCodes.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/HTTPStatusCodes/HTTPStatusCodes.xcodeproj/xcshareddata/xcschemes/HTTPStatusCodes.xcscheme
+++ b/HTTPStatusCodes/HTTPStatusCodes.xcodeproj/xcshareddata/xcschemes/HTTPStatusCodes.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0640"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "908CDFA91B5966CB0009CA5D"
+               BuildableName = "HTTPStatusCodes.framework"
+               BlueprintName = "HTTPStatusCodes"
+               ReferencedContainer = "container:HTTPStatusCodes.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "908CDFB41B5966CB0009CA5D"
+               BuildableName = "HTTPStatusCodesTests.xctest"
+               BlueprintName = "HTTPStatusCodesTests"
+               ReferencedContainer = "container:HTTPStatusCodes.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "908CDFB41B5966CB0009CA5D"
+               BuildableName = "HTTPStatusCodesTests.xctest"
+               BlueprintName = "HTTPStatusCodesTests"
+               ReferencedContainer = "container:HTTPStatusCodes.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "908CDFA91B5966CB0009CA5D"
+            BuildableName = "HTTPStatusCodes.framework"
+            BlueprintName = "HTTPStatusCodes"
+            ReferencedContainer = "container:HTTPStatusCodes.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "908CDFA91B5966CB0009CA5D"
+            BuildableName = "HTTPStatusCodes.framework"
+            BlueprintName = "HTTPStatusCodes"
+            ReferencedContainer = "container:HTTPStatusCodes.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "908CDFA91B5966CB0009CA5D"
+            BuildableName = "HTTPStatusCodes.framework"
+            BlueprintName = "HTTPStatusCodes"
+            ReferencedContainer = "container:HTTPStatusCodes.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/HTTPStatusCodes/HTTPStatusCodes/HTTPStatusCodes.h
+++ b/HTTPStatusCodes/HTTPStatusCodes/HTTPStatusCodes.h
@@ -1,0 +1,19 @@
+//
+//  HTTPStatusCodes.h
+//  HTTPStatusCodes
+//
+//  Created by MORITANAOKI on 2015/07/18.
+//  Copyright (c) 2015年 HTTPStatusCodes. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for HTTPStatusCodes.
+FOUNDATION_EXPORT double HTTPStatusCodesVersionNumber;
+
+//! Project version string for HTTPStatusCodes.
+FOUNDATION_EXPORT const unsigned char HTTPStatusCodesVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <HTTPStatusCodes/PublicHeader.h>
+
+

--- a/HTTPStatusCodes/HTTPStatusCodes/Info.plist
+++ b/HTTPStatusCodes/HTTPStatusCodes/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>HTTPStatusCodes.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/HTTPStatusCodes/HTTPStatusCodesTests/HTTPStatusCodesTests.swift
+++ b/HTTPStatusCodes/HTTPStatusCodesTests/HTTPStatusCodesTests.swift
@@ -1,0 +1,36 @@
+//
+//  HTTPStatusCodesTests.swift
+//  HTTPStatusCodesTests
+//
+//  Created by MORITANAOKI on 2015/07/18.
+//  Copyright (c) 2015年 HTTPStatusCodes. All rights reserved.
+//
+
+import UIKit
+import XCTest
+
+class HTTPStatusCodesTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        XCTAssert(true, "Pass")
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measureBlock() {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}

--- a/HTTPStatusCodes/HTTPStatusCodesTests/Info.plist
+++ b/HTTPStatusCodes/HTTPStatusCodesTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>HTTPStatusCodes.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ In your source file:
 import HTTPStatusCodes
 ```
 
+With Carthage:
+
+```ogdl
+github "rhodgkins/SwiftHTTPStatusCodes"
+```
+
 Or drop `HTTPStatusCodes.swift` into your project.
 
 ## Helper methods


### PR DESCRIPTION
I added project for [Carthage/Carthage](https://github.com/Carthage/Carthage) distribution.

Carthage is a new dependency management tools. It makes dynamic framework which can reduce Xcode build time.

Thanks!