### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:4.0
 //
 //  Created by Richard Hodgkins on 07/06/2016.
 //  Copyright (c) 2016 Richard Hodgkins. All rights reserved.
@@ -6,5 +7,23 @@
 import PackageDescription
 
 let package = Package(
-  name: "HTTPStatusCodes"
+    name: "HTTPStatusCodes",
+    products: [
+        .library(
+            name: "HTTPStatusCodes",
+            targets: ["HTTPStatusCodes"]),
+        ],
+    targets: [
+        .target(
+            name: "HTTPStatusCodes",
+            path: "Sources"),
+        .testTarget(
+            name: "HTTPStatusCodesTests",
+            dependencies: ["HTTPStatusCodes"],
+            path: "Tests/HTTPStatusCodesTests",
+            sources: [
+                "HTTPStatusCodesTests.swift",
+                "RegressionTests.swift"
+            ])
+    ]
 )

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ If this library is out of date compared to this page please open an issue and I 
 
 Swift 3.0 support is added in version 3.1 of this framework. For use with older versions of Swift use version 3.0.
 
+### Swift Package Manager
+
+`Package.swift`:
+```swift
+.package(url: "https://github.com/rhodgkins/SwiftHTTPStatusCodes.git", .upToNextMajor(from: "3.0.0"))
+```
+
 ### Carthage
 
 `Cartfile`:


### PR DESCRIPTION
Due to current structure much of it has to be specified manually, but this adds Swift Package Manager support for the library + Swift tests