### PR TITLE
fix build error with Xcode12

### DIFF
--- a/Tests/HTTPStatusCodes.xcconfig
+++ b/Tests/HTTPStatusCodes.xcconfig
@@ -18,11 +18,6 @@ COMBINE_HIDPI_IMAGES                    = YES
 
 SUPPORTED_PLATFORMS                     = macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator
 
-VALID_ARCHS[sdk=iphone*]                = arm64 armv7 armv7s
-VALID_ARCHS[sdk=appletv*]               = arm64
-VALID_ARCHS[sdk=macosx*]                = i386 x86_64
-VALID_ARCHS[sdk=watch*]                 = armv7k
-
 SWIFT_VERSION = 5.0
 
 LD_RUNPATH_SEARCH_PATHS[sdk=iphone*]    = $(inherited) @executable_path/Frameworks @loader_path/Frameworks
@@ -39,7 +34,7 @@ INFOPLIST_FILE[sdk=watch*]              = $(PROJECT_NAME)/SupportingFiles/Info-w
 
 // iOS
 CODE_SIGN_IDENTITY[sdk=iphoneos*]       = iPhone Developer
-IPHONEOS_DEPLOYMENT_TARGET[sdk=iphone*] = 8.0
+IPHONEOS_DEPLOYMENT_TARGET[sdk=iphone*] = 9.0
 TARGETED_DEVICE_FAMILY[sdk=iphone*]     = 1,2
 
 // tvOS

--- a/Tests/HTTPStatusCodes.xcodeproj/project.pbxproj
+++ b/Tests/HTTPStatusCodes.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = "Rich H";
 				TargetAttributes = {
 					440D14111A99DD1D00EEB60B = {
@@ -218,11 +218,11 @@
 			};
 			buildConfigurationList = 440D140C1A99DD1D00EEB60B /* Build configuration list for PBXProject "HTTPStatusCodes" */;
 			compatibilityVersion = "Xcode 8.0";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
+				Base,
 			);
 			mainGroup = 440D14081A99DD1D00EEB60B;
 			productRefGroup = 440D14131A99DD1D00EEB60B /* Products */;
@@ -309,6 +309,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -366,6 +367,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;

--- a/Tests/HTTPStatusCodes.xcodeproj/xcshareddata/xcschemes/HTTPStatusCodes.xcscheme
+++ b/Tests/HTTPStatusCodes.xcodeproj/xcshareddata/xcschemes/HTTPStatusCodes.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,8 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -54,17 +54,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "440D14111A99DD1D00EEB60B"
-            BuildableName = "HTTPStatusCodes.framework"
-            BlueprintName = "HTTPStatusCodes"
-            ReferencedContainer = "container:HTTPStatusCodes.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -85,8 +74,6 @@
             ReferencedContainer = "container:HTTPStatusCodes.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
- [x] apply Xcode12 recommended settings (`IPHONEOS_DEPLOYMENT_TARGET = 8.0` is no longer supported)
- [x] remove VALID_ARCHS because it's deprecated in Xcode12. see [release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-beta-release-notes) for details.

I tested with Xcode12 public beta6.